### PR TITLE
Update example alternativeFormatContactEmail

### DIFF
--- a/src/digitalmarketplace/components/attachment/__snapshots__/template.test.js.snap
+++ b/src/digitalmarketplace/components/attachment/__snapshots__/template.test.js.snap
@@ -137,7 +137,7 @@ exports[`Attachment with alternative format contact email matches existing snaps
     </span>
   </summary>
   <div class=\\"govuk-details__text\\">
-        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email <a href=\\"mailto:help@digitalmarketplace.service.gov.uk\\" target=\\"_blank\\" class=\\"govuk-link\\">help@digitalmarketplace.service.gov.uk</a>. Please tell us what format you need. It will help us if you say what assistive technology you use.
+        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email <a href=\\"mailto:info@crowncommercial.gov.uk\\" target=\\"_blank\\" class=\\"govuk-link\\">info@crowncommercial.gov.uk</a>. Please tell us what format you need. It will help us if you say what assistive technology you use.
 
   </div>
 </details>

--- a/src/digitalmarketplace/components/attachment/attachment.yaml
+++ b/src/digitalmarketplace/components/attachment/attachment.yaml
@@ -128,7 +128,7 @@ examples:
         text: "Attachment with alternative format contact email"
         href: "https://digitalmarketplace.service.gov.uk/attachment.pdf"
       contentType: 'application/pdf'
-      alternativeFormatContactEmail: 'help@digitalmarketplace.service.gov.uk'
+      alternativeFormatContactEmail: 'info@crowncommercial.gov.uk'
   - name: with alternative format HTML
     description: 'Attachment with alternative format HTML'
     data:


### PR DESCRIPTION
https://trello.com/c/UIQWRdCi/199-make-sure-helpdigitalmarketplaceservicegovuk-and-other-non-google-group-emails-start-continue-to-work

The previous example confused me - I didn't realise it was an example, and thought we were showing the non-existent 'help@' address to real users. Switch the example to match what we're really using in the apps. This should reduce the risk that people in future make the same mistake as I did.