### PR TITLE
Make the banner component  for V2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 See below for Changelog examples.
 
+## Unreleased Changes
+🆕 New features:
+
+  - Add banner component with directions to apply to new DMP framework PR #480
+
 ## 2.9.2
 
 🔧 Fixes:

--- a/src/digitalmarketplace/all.js
+++ b/src/digitalmarketplace/all.js
@@ -7,6 +7,7 @@ import { getConsentCookie } from './helpers/cookie/cookie-functions'
 import ListInput from './components/list-input/list-input'
 import OptionSelect from './components/option-select/option-select'
 import SearchBox from './components/search-box/search-box'
+import NewFrameworkBanner from './components/new-framework-banner/new-framework-banner'
 
 function initAll (options) {
   // Set the options to an empty object by default if no options are passed.
@@ -44,6 +45,11 @@ function initAll (options) {
   $SearchBox.forEach(function ($SearchBox) {
     new SearchBox($SearchBox).init()
   })
+
+  var $NewFrameworkBanner = scope.querySelectorAll('[data-module="govuk-notification-banner"]')
+  $NewFrameworkBanner.forEach(function ($NewFrameworkBanner) {
+    new NewFrameworkBanner($NewFrameworkBanner).init()
+  })
 }
 
 export {
@@ -54,5 +60,6 @@ export {
   CookieSettings,
   ListInput,
   OptionSelect,
-  SearchBox
+  SearchBox,
+  NewFrameworkBanner
 }

--- a/src/digitalmarketplace/all.scss
+++ b/src/digitalmarketplace/all.scss
@@ -7,3 +7,4 @@
 @import "components/search-box/search-box";
 @import "components/attachment/attachment";
 @import "components/previous-next-pagination/previous-next-pagination";
+@import "components/new-framework-banner/new-framework-banner";

--- a/src/digitalmarketplace/components/new-framework-banner/README.md
+++ b/src/digitalmarketplace/components/new-framework-banner/README.md
@@ -1,0 +1,8 @@
+# New Framework Banner
+
+A banner to inform users where to sign up for the new DOS6 framework.
+
+Although it is only to be shown on a few pages, these pages are on multiple apps.
+This component allows us to only have to maintain the banner in one place.
+
+This will likely be updated in the future with directions for G-Cloud 13.

--- a/src/digitalmarketplace/components/new-framework-banner/_new-framework-banner.scss
+++ b/src/digitalmarketplace/components/new-framework-banner/_new-framework-banner.scss
@@ -1,0 +1,79 @@
+@include govuk-exports("govuk/component/notification-banner") {
+  .govuk-notification-banner {
+    @include govuk-font($size: 19);
+    @include govuk-responsive-margin(8, "bottom");
+
+    border: $govuk-border-width solid $govuk-brand-colour;
+
+    background-color: $govuk-brand-colour;
+
+    &:focus {
+      outline: $govuk-focus-width solid $govuk-focus-colour;
+    }
+  }
+
+  .govuk-notification-banner__header {
+    padding: 2px govuk-spacing(3) govuk-spacing(1);
+
+    // Ensures the notification header appears separate to the notification body text in high contrast mode
+    border-bottom: 1px solid transparent;
+
+    @include govuk-media-query($from: tablet) {
+      padding: 2px govuk-spacing(4) govuk-spacing(1);
+    }
+  }
+
+  .govuk-notification-banner__title {
+    @include govuk-font($size: 19, $weight: bold);
+
+    margin: 0;
+
+    padding: 0;
+
+    color: govuk-colour("white");
+  }
+
+  .govuk-notification-banner__content {
+    $padding-tablet: govuk-spacing(4);
+    @include govuk-text-colour;
+    padding: govuk-spacing(3);
+
+    background-color: $govuk-body-background-colour;
+
+    @include govuk-media-query($from: tablet) {
+      padding: $padding-tablet;
+    }
+
+    // Wrap content at the same place that a 2/3 grid column ends, to maintain
+    // shorter line-lengths when the notification banner is full width
+    > * {
+      // When elements have their own padding (like lists), include the padding
+      // in the max-width calculation
+      box-sizing: border-box;
+
+      // Calculate the internal width of a two-thirds column...
+      $two-col-width: ($govuk-page-width * 2 / 3) - ($govuk-gutter * 1 / 3);
+
+      // ...and then factor in the left border and padding
+      $banner-exterior: ($padding-tablet + $govuk-border-width);
+      max-width: $two-col-width - $banner-exterior;
+    }
+
+    > :last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  .govuk-notification-banner__heading {
+    @include govuk-font($size: 24, $weight: bold);
+
+    margin: 0 0 govuk-spacing(3) 0;
+
+    padding: 0;
+  }
+
+  .govuk-notification-banner__link {
+    @include govuk-link-common;
+    @include govuk-link-style-no-visited-state;
+  }
+}

--- a/src/digitalmarketplace/components/new-framework-banner/macro.njk
+++ b/src/digitalmarketplace/components/new-framework-banner/macro.njk
@@ -1,0 +1,3 @@
+{% macro dmNewFrameworkBanner() %}
+  {%- include "digitalmarketplace/components/new-framework-banner/template.njk" -%}
+{% endmacro %}

--- a/src/digitalmarketplace/components/new-framework-banner/new-framework-banner.js
+++ b/src/digitalmarketplace/components/new-framework-banner/new-framework-banner.js
@@ -1,0 +1,53 @@
+function NewFrameworkBanner ($module) {
+  this.$module = $module
+}
+
+/**
+ * Initialise the component
+ */
+NewFrameworkBanner.prototype.init = function () {
+  var $module = this.$module
+  // Check for module
+  if (!$module) {
+    return
+  }
+
+  this.setFocus()
+}
+
+/**
+ * Focus the element
+ *
+ * If `role="alert"` is set, focus the element to help some assistive technologies
+ * prioritise announcing it.
+ *
+ * You can turn off the auto-focus functionality by setting `data-disable-auto-focus="true"` in the
+ * component HTML. You might wish to do this based on user research findings, or to avoid a clash
+ * with another element which should be focused when the page loads.
+ */
+NewFrameworkBanner.prototype.setFocus = function () {
+  var $module = this.$module
+
+  if ($module.getAttribute('data-disable-auto-focus') === 'true') {
+    return
+  }
+
+  if ($module.getAttribute('role') !== 'alert') {
+    return
+  }
+
+  // Set tabindex to -1 to make the element focusable with JavaScript.
+  // Remove the tabindex on blur as the component doesn't need to be focusable after the page has
+  // loaded.
+  if (!$module.getAttribute('tabindex')) {
+    $module.setAttribute('tabindex', '-1')
+
+    $module.addEventListener('blur', function () {
+      $module.removeAttribute('tabindex')
+    })
+  }
+
+  $module.focus()
+}
+
+export default NewFrameworkBanner

--- a/src/digitalmarketplace/components/new-framework-banner/new-framework-banner.yaml
+++ b/src/digitalmarketplace/components/new-framework-banner/new-framework-banner.yaml
@@ -1,0 +1,3 @@
+params:
+examples:
+  - name: default

--- a/src/digitalmarketplace/components/new-framework-banner/template.njk
+++ b/src/digitalmarketplace/components/new-framework-banner/template.njk
@@ -1,0 +1,15 @@
+<div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      Important supplier information
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <p class="govuk-notification-banner__heading">
+      Supplier information for Digital Outcomes 6 is not available from this page.
+      <a class="govuk-notification-banner__link" href="https://www.applytosupply.digitalmarketplace.service.gov.uk">
+        Start or continue your application for the Digital Outcomes 6 framework.
+      </a>
+    </p>
+  </div>
+</div>


### PR DESCRIPTION
- Add the HTML and css for the banner 
- Update change log

This is part of the ticket [OST-134](https://crowncommercialservice.atlassian.net/browse/OST-134)

Once this has been merged we will need to create a new release (2.10.0) and then update all the supplier-frontend app.

For the stylings and JavaScript, I got them from [govuk-frontend/notification-banner](https://github.com/alphagov/govuk-frontend/tree/a8bcd1379aedf3e057ea3eb7d606b91695b37c2a/src/govuk/components/notification-banner) and removed the parts we didn't need (just some CSS)