### PR TITLE
Release 2.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 See below for Changelog examples.
 
+## 2.10.2
+
+🔧 Fixes:
+  - Remove email from URL sent to Google Analytics for an edge case [PR #493](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/494)
+
 ## 2.10.0
 🆕 New features:
 

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "peerDependencies": {
     "govuk-frontend": "^2.13.0"
   },


### PR DESCRIPTION
## 2.10.2

🔧 Fixes:
  - Remove email from URL sent to Google Analytics for an edge case [PR #493](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/494)