### PR TITLE
Update version number and add link to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 See below for Changelog examples.
 
+## 3.1.3
+
+🔧 Fixes:
+  - Updates footer link [PR #516](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/516)
+
+  🆕 New features:
+
+  - Add link to docs [PR #517](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/517)
+
 ## 3.1.2
 
 🔧 Fixes:

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "peerDependencies": {
     "govuk-frontend": "^3.9.1"
   },


### PR DESCRIPTION
## 3.1.3

🔧 Fixes:
  - Updates footer link [PR #516](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/516)

  🆕 New features:

  - Add link to docs [PR #517](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/517)