### PR TITLE
Update-footer-link-add-docs-link-and-update-changelog-and-version-number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,47 @@
 
 See below for Changelog examples.
 
-## 2.10.2
+## 3.1.3
 
 🔧 Fixes:
-  - Remove email from URL sent to Google Analytics for an edge case [PR #493](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/494)
+  - Updates footer link [PR #516](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/516)
 
-## 2.10.0
+  🆕 New features:
+
+  - Add link to docs [PR #517](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/517)
+
+## 3.1.2
+
+🔧 Fixes:
+  - Remove email from URL sent to Google Analytics for an edge case [PR #493](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/493)
+
+## 3.1.0
+
 🆕 New features:
 
-  - Add banner component with directions to apply to new DMP framework PR #480
+  - Add banner component with directions to apply to new DMP framework [PR #474](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/474)
 
-## 2.9.2
+## 3.0.1
 
 🔧 Fixes:
 
-  - The Node.js Package workflow now publishes to npm correctly (backports PRs [#303](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/303), [#307](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/307), [#308](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/308))
+  - The Node.js Package workflow now publishes to npm correctly (PRs [#303](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/303), [#307](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/307), [#308](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/308))
+
+## 3.0.0
+
+💥 Breaking changes:
+
+  - GOV.UK Frontend updated to version 3
+
+    To migrate, follow the instructions on the [govuk-frontend repo](https://github.com/alphagov/govuk-frontend/blob/master/CHANGELOG.md#300-breaking-release)
+
+    ([PR #149](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/149))
+
+  - The list input component no longer has a suffix on the id of the first input element ([PR #238](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/238))
+
+🔧 Fixes:
+
+  - Option select header spacing adjustments [PR #219](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/219)
 
 ## 2.9.1
 
@@ -47,7 +73,6 @@ See below for Changelog examples.
 🆕 New features:
 
   - A description can now be added to the Attachment component [PR #230](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/230)
-
 
 ## 2.6.0
 
@@ -105,7 +130,7 @@ See below for Changelog examples.
 🆕 New features:
 
   - Footer component now contains link to accessibility statement [PR #180](https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/180)
-
+  
 ## 2.0.0
 
 💥 Breaking changes:
@@ -151,7 +176,7 @@ See below for Changelog examples.
 ## 1.0.0
 
 💥 Breaking changes:
-
+  
 - Move Digital Marketplace files around
 
   We've moved some files around so their locations are consistent with govuk-frontend.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Digital Marketplace GOV.UK Frontend ·
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
-[![Known Vulnerabilities](https://snyk.io/test/github/alphagov/digitalmarketplace-govuk-frontend/badge.svg?targetFile=package.json)](https://snyk.io/test/github/alphagov/digitalmarketplace-govuk-frontend?targetFile=package.json)
+[![Known Vulnerabilities](https://snyk.io/test/github/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/badge.svg?targetFile=package.json)](https://snyk.io/test/github/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/badge.svg?targetFile=package.json)
 =====================
 
 This repository provides a central repository for custom components used in the Digital Marketplace
@@ -93,7 +93,7 @@ Run `npm run dev`
 
 ## 3. Testing features in apps
 
-Follow the steps in `docs/publishing-a-pre-release.md` to push a branch to GitHub as a release that can be consumed by other NodeJS apps.
+Follow the steps in [`docs/publishing-a-pre-release.md`](docs/publishing-a-pre-release.md) to push a branch to GitHub as a release that can be consumed by other NodeJS apps.
 
 Alternatively, you can create a package locally using `npm run build`:
 
@@ -105,7 +105,13 @@ Alternatively, you can create a package locally using `npm run build`:
 
 ## 3. Publishing
 
-Follow the steps in `docs/publishing.md`.
+Follow the steps in [`docs/publishing.md`](docs/publishing.md).
+
+## Using govuk-frontend v2
+
+Release series 2.x.x of digitalmarketplace-govuk-frontend supports govuk-frontend v2.
+
+If you need to backport changes to the 2.x.x series follow the steps in [`docs/backporting.md`](docs/backporting.md).
 
 ## Licence
 
@@ -115,9 +121,9 @@ This covers both the codebase and any sample code in the documentation.
 The documentation is [&copy; Crown copyright][copyright] and available under the terms
 of the [Open Government 3.0][ogl] licence.
 
-[Digital Marketplace]: https://github.com/alphagov?q=digitalmarketplace&type=&language=
+[Digital Marketplace]: https://github.com/Crown-Commercial-Service?q=digitalmarketplace&type=&language=
 [GOV.UK Frontend]: https://github.com/alphagov/govuk-frontend
-[Digital Marketplace GOV.UK Frontend]: https://github.com/alphagov/digitalmarketplace-govuk-frontend
+[Digital Marketplace GOV.UK Frontend]: https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend
 
 [mit]: LICENCE
 [copyright]: http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/

--- a/package/package.json
+++ b/package/package.json
@@ -1,9 +1,9 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "2.10.2",
+  "version": "3.1.3",
   "peerDependencies": {
-    "govuk-frontend": "^2.13.0"
+    "govuk-frontend": "^3.9.1"
   },
   "main": "digitalmarketplace/all.js",
   "sass": "digitalmarketplace/all.scss",

--- a/python-tests/__snapshots__/test_templates.ambr
+++ b/python-tests/__snapshots__/test_templates.ambr
@@ -105,7 +105,7 @@
                   
                     
                       <li class="govuk-footer__list-item">
-                        <a class="govuk-footer__link" href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide">
+                        <a class="govuk-footer__link" href="https://www.gov.uk/guidance/how-to-apply-to-sell-on-the-digital-outcomes-framework">
                           Applying to sell on the DOS framework
                         </a>
                       </li>

--- a/src/digitalmarketplace/components/footer/__snapshots__/template.test.js.snap
+++ b/src/digitalmarketplace/components/footer/__snapshots__/template.test.js.snap
@@ -48,7 +48,7 @@ exports[`footer renders a footer component with all our standard links 1`] = `
                       </a>
                     </li>
                     <li class=\\"govuk-footer__list-item\\">
-                      <a class=\\"govuk-footer__link\\" href=\\"https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide\\">
+                      <a class=\\"govuk-footer__link\\" href=\\"https://www.gov.uk/guidance/how-to-apply-to-sell-on-the-digital-outcomes-framework\\">
                         Applying to sell on the DOS framework
                       </a>
                     </li>
@@ -105,7 +105,7 @@ exports[`footer renders a footer component with all our standard links 1`] = `
               Built by the <a href=\\"https://www.gov.uk/government/organisations/government-digital-service\\" class=\\"govuk-footer__link\\">Government Digital Service</a>
             </div>
 
-        <svg role=\\"presentation\\" focusable=\\"false\\" class=\\"govuk-footer__licence-logo\\" xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 483.2 195.7\\" height=\\"17\\" width=\\"41\\">
+        <svg aria-hidden=\\"true\\" focusable=\\"false\\" class=\\"govuk-footer__licence-logo\\" xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 483.2 195.7\\" height=\\"17\\" width=\\"41\\">
           <path fill=\\"currentColor\\" d=\\"M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145\\"></path>
         </svg>
         <span class=\\"govuk-footer__licence-description\\">

--- a/src/digitalmarketplace/components/footer/template.njk
+++ b/src/digitalmarketplace/components/footer/template.njk
@@ -38,7 +38,7 @@
           "text": 'Applying to sell on the G-Cloud framework'
         },
         {
-          "href": 'https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide',
+          "href": 'https://www.gov.uk/guidance/how-to-apply-to-sell-on-the-digital-outcomes-framework',
           "text": 'Applying to sell on the DOS framework'
         },
         {


### PR DESCRIPTION
## 3.1.3

🔧 Fixes:
  - Updates footer link [PR #516](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/516)

  🆕 New features:

  - Add link to docs [PR #517](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/517)