### PR TITLE
Update footer link, for frontend apps

### DIFF
--- a/python-tests/__snapshots__/test_templates.ambr
+++ b/python-tests/__snapshots__/test_templates.ambr
@@ -105,7 +105,7 @@
                   
                     
                       <li class="govuk-footer__list-item">
-                        <a class="govuk-footer__link" href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide">
+                        <a class="govuk-footer__link" href="https://www.gov.uk/guidance/how-to-apply-to-sell-on-the-digital-outcomes-framework">
                           Applying to sell on the DOS framework
                         </a>
                       </li>

--- a/src/digitalmarketplace/components/footer/__snapshots__/template.test.js.snap
+++ b/src/digitalmarketplace/components/footer/__snapshots__/template.test.js.snap
@@ -48,7 +48,7 @@ exports[`footer renders a footer component with all our standard links 1`] = `
                       </a>
                     </li>
                     <li class=\\"govuk-footer__list-item\\">
-                      <a class=\\"govuk-footer__link\\" href=\\"https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide\\">
+                      <a class=\\"govuk-footer__link\\" href=\\"https://www.gov.uk/guidance/how-to-apply-to-sell-on-the-digital-outcomes-framework\\">
                         Applying to sell on the DOS framework
                       </a>
                     </li>

--- a/src/digitalmarketplace/components/footer/template.njk
+++ b/src/digitalmarketplace/components/footer/template.njk
@@ -38,7 +38,7 @@
           "text": 'Applying to sell on the G-Cloud framework'
         },
         {
-          "href": 'https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide',
+          "href": 'https://www.gov.uk/guidance/how-to-apply-to-sell-on-the-digital-outcomes-framework',
           "text": 'Applying to sell on the DOS framework'
         },
         {


### PR DESCRIPTION
As requested via the zen/help-desk, modifications to the footer links were required. As described in the ticket; the 'Applying to sell on the DOS framework' link should point to the new DOS 6 page https://www.gov.uk/guidance/how-to-apply-to-sell-on-the-digital-outcomes-framework

With correct permissions, see ticket:
https://crowncommercial.zendesk.com/agent/tickets/34497