### PR TITLE
OST-509-Updates-Banner-Text-V2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 See below for Changelog examples.
 
+## 2.10.4
+
+🔧 Fixes:
+  - Updates banner text [PR #533](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/533)
+
 ## 2.10.3
 
 🔧 Fixes:

--- a/src/digitalmarketplace/components/new-framework-banner/template.njk
+++ b/src/digitalmarketplace/components/new-framework-banner/template.njk
@@ -6,9 +6,9 @@
   </div>
   <div class="govuk-notification-banner__content">
     <p class="govuk-notification-banner__heading">
-      Supplier applications for Digital Outcomes 6 are not available from this page.
+      Supplier applications for G-Cloud 13 are not available from this page.
       <a class="govuk-notification-banner__link" href="https://www.applytosupply.digitalmarketplace.service.gov.uk">
-        Start or continue your application for the Digital Outcomes 6 framework.
+        Start or continue your application for the G-Cloud 13 framework.
       </a>
     </p>
   </div>


### PR DESCRIPTION
(V2) Updates the banner to reflect the new G13 wording, as DOS6 is now obsolete in this regard.