### PR TITLE
Release-3.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 See below for Changelog examples.
 
-## 3.1.4
+## 3.1.5
 
 🔧 Fixes:
   - Updates banner text [PR #531](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/531)
+
+## 3.1.4
+
+🔧 Fixes:
+  - Skip this version, as it already exists in npm, causing a 400 error on publish.
 
 ## 3.1.3
 

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "peerDependencies": {
     "govuk-frontend": "^3.9.1"
   },


### PR DESCRIPTION
## 3.1.5

🔧 Fixes:
  - Updates banner text [PR #531](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/531)

## 3.1.4

🔧 Fixes:
  - Skip this version, as it already exists in npm, causing a 400 error on publish.