### PR TITLE
Release-2.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 See below for Changelog examples.
 
-## 2.10.4
+## 2.10.5
 
 🔧 Fixes:
   - Updates banner text [PR #533](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/533)
+
+## 2.10.4
+
+🔧 Fixes:
+  - Skip this version, as it already exists in npm, causing a 400 error on publish.
 
 ## 2.10.3
 

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "peerDependencies": {
     "govuk-frontend": "^2.13.0"
   },


### PR DESCRIPTION
## 2.10.5

🔧 Fixes:
  - Updates banner text [PR #533](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/533)

## 2.10.4

🔧 Fixes:
  - Skip this version, as it already exists in npm, causing a 400 error on publish.