### PR TITLE
release-3.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See below for Changelog examples.
 
+## 3.1.6
+
+🔧 Fixes:
+
+  - Update Banner helper text, for DMP 1.5 [PR #638](https://github.com/Crown-Commercial-Service/ccs-digitalmarketplace-govuk-frontend/pull/638)
+
 ## 3.1.5
 
 🔧 Fixes:

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "peerDependencies": {
     "govuk-frontend": "^3.9.1"
   },


### PR DESCRIPTION
## 3.1.6

🔧 Fixes:

  - Update Banner helper text, for DMP 1.5 [PR #638](https://github.com/Crown-Commercial-Service/ccs-digitalmarketplace-govuk-frontend/pull/638)