### PR TITLE
Release 2.10.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ See below for Changelog examples.
 
 🔧 Fixes:
 
-  - Update Banner helper text, for DMP 1.5 [PR #164](https://github.com/Crown-Commercial-Service/ccs-digitalmarketplace-govuk-frontend/pull/164)
+  - Update Banner helper text, for DMP 1.5 [PR #640](https://github.com/Crown-Commercial-Service/ccs-digitalmarketplace-govuk-frontend/pull/640)
 
 ## 2.10.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See below for Changelog examples.
 
+## 2.10.6
+
+🔧 Fixes:
+
+  - Update Banner helper text, for DMP 1.5 [PR #164](https://github.com/Crown-Commercial-Service/ccs-digitalmarketplace-govuk-frontend/pull/164)
+
 ## 2.10.5
 
 🔧 Fixes:

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "2.10.5",
+  "version": "2.10.6",
   "peerDependencies": {
     "govuk-frontend": "^2.13.0"
   },

--- a/src/digitalmarketplace/components/new-framework-banner/template.njk
+++ b/src/digitalmarketplace/components/new-framework-banner/template.njk
@@ -6,10 +6,10 @@
   </div>
   <div class="govuk-notification-banner__content">
     <p class="govuk-notification-banner__heading">
-      Supplier applications for G-Cloud 13 are not available from this page.
-      <a class="govuk-notification-banner__link" href="https://www.applytosupply.digitalmarketplace.service.gov.uk">
-        Start or continue your application for the G-Cloud 13 framework.
-      </a>
+      03/08/2022: We have taken the difficult decision to delay the launch of Digital Outcomes 6 (DOS6). Buyers and suppliers can find out more by reading our news item:
+    <a class="govuk-notification-banner__link" href="https://www.crowncommercial.gov.uk/news/digital-outcomes-g-cloud-an-update-for-ccs-customers-and-suppliers">
+      Digital Outcomes/G-Cloud: an update for CCS customers and suppliers.
+    </a>
     </p>
   </div>
 </div>


### PR DESCRIPTION
## 2.10.6

🔧 Fixes:

  - Update Banner helper text, for DMP 1.5 [PR #640](https://github.com/Crown-Commercial-Service/ccs-digitalmarketplace-govuk-frontend/pull/640)