### PR TITLE
Release 3.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See below for Changelog examples.
 
+## 3.1.8
+
+🔧 Fixes:
+
+  - Update Banner helper text once again, for DMP 1.0 [PR #647](https://github.com/Crown-Commercial-Service/ccs-digitalmarketplace-govuk-frontend/pull/647)
+
 ## 3.1.7
 
 🔧 Fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ See below for Changelog examples.
 
 🔧 Fixes:
 
-  - Update Banner helper text once again, for DMP 1.0 [PR #647](https://github.com/Crown-Commercial-Service/ccs-digitalmarketplace-govuk-frontend/pull/647)
+  - Update Banner helper text once again, for DMP 1.0 [PR #671](https://github.com/Crown-Commercial-Service/ccs-digitalmarketplace-govuk-frontend/pull/671)
 
 ## 3.1.7
 

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "peerDependencies": {
     "govuk-frontend": "^3.9.1"
   },

--- a/src/digitalmarketplace/components/new-framework-banner/template.njk
+++ b/src/digitalmarketplace/components/new-framework-banner/template.njk
@@ -2,12 +2,12 @@
 
 {% set html %}
   <p class="govuk-notification-banner__heading">
-    26/08/22: a new update on G-Cloud 12 and G-Cloud 13 has been published on the CCS website
-    <a class="govuk-notification-banner__link" href="https://www.crowncommercial.gov.uk/news/digital-outcomes-g-cloud-an-update-for-ccs-customers-and-suppliers">on the CCS website</a>.
+    21/09/2022: new customer update has been published on the
+    <a class="govuk-notification-banner__link" href="https://www.crowncommercial.gov.uk/agreements/RM1557.13">G-Cloud 13 webpage</a>
   </p>
 {% endset %}
 
 {{ govukNotificationBanner({
-  "titleText": 'Important supplier information',
+  "titleText": 'Important information',
   "html": html
 }) }}


### PR DESCRIPTION
## 3.1.8

🔧 Fixes:

  - Update Banner helper text once again, for DMP 1.5 [PR #671](https://github.com/Crown-Commercial-Service/ccs-digitalmarketplace-govuk-frontend/pull/671)

Request from Zendesk: https://crowncommercial.zendesk.com/agent/tickets/42767