### PR TITLE
Release 2.10.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See below for Changelog examples.
 
+## 2.10.8
+
+🔧 Fixes:
+
+  - Update Banner helper text, for DMP 1.5 [PR #672](https://github.com/Crown-Commercial-Service/ccs-digitalmarketplace-govuk-frontend/pull/672)
+
 ## 2.10.7
 
 🔧 Fixes:

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "2.10.7",
+  "version": "2.10.8",
   "peerDependencies": {
     "govuk-frontend": "^2.13.0"
   },

--- a/src/digitalmarketplace/components/new-framework-banner/template.njk
+++ b/src/digitalmarketplace/components/new-framework-banner/template.njk
@@ -1,13 +1,13 @@
 <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
   <div class="govuk-notification-banner__header">
     <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-      Important supplier information
+      Important information
     </h2>
   </div>
   <div class="govuk-notification-banner__content">
     <p class="govuk-notification-banner__heading">
-      26/08/22: a new update on G-Cloud 12 and G-Cloud 13 has been published on the CCS website
-      <a class="govuk-notification-banner__link" href="https://www.crowncommercial.gov.uk/news/digital-outcomes-g-cloud-an-update-for-ccs-customers-and-suppliers">on the CCS website</a>.
+      21/09/2022: new customer update has been published on the
+      <a class="govuk-notification-banner__link" href="https://www.crowncommercial.gov.uk/agreements/RM1557.13">G-Cloud 13 webpage</a>.
     </p>
   </div>
 </div>


### PR DESCRIPTION
## 2.10.9

🔧 Fixes:

  - Update Banner helper text, for DMP 1.5 [PR #672](https://github.com/Crown-Commercial-Service/ccs-digitalmarketplace-govuk-frontend/pull/672)

Request from Zendesk: https://crowncommercial.zendesk.com/agent/tickets/42767