### PR TITLE
Release 3.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See below for Changelog examples.
 
+## 3.10.0
+
+🔧 Changes:
+
+  - Update Banner text to ask to show G-Cloud 13 is live [PR #700](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/700)
+
 ## 3.1.9
 
 🔧 Changes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13121,7 +13121,7 @@
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
     "lodash.isfinite": {

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "3.1.9",
+  "version": "3.10.0",
   "peerDependencies": {
     "govuk-frontend": "^3.9.1"
   },


### PR DESCRIPTION
## 3.10.0

🔧 Changes:

  - Update Banner text to ask to show G-Cloud 13 is live [PR #700](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/700)
