### PR TITLE
Release 2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See below for Changelog examples.
 
+## 2.11.0
+
+🔧 Changes:
+
+  - Update Banner text to ask to show G-Cloud 13 is live [PR #701](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/701)
+
 ## 2.10.9
 
 🔧 Changes:

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "2.10.9",
+  "version": "2.11.0",
   "peerDependencies": {
     "govuk-frontend": "^2.13.0"
   },


### PR DESCRIPTION
## 2.11.0

🔧 Changes:

  - Update Banner text to ask to show G-Cloud 13 is live [PR #701](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/701)
