### PR TITLE
OST-583 - Update the banner, yet again

### DIFF
--- a/src/digitalmarketplace/components/new-framework-banner/macro.njk
+++ b/src/digitalmarketplace/components/new-framework-banner/macro.njk
@@ -1,3 +1,3 @@
-{% macro dmNewFrameworkBanner() %}
+{% macro dmNewFrameworkBanner(params) %}
   {%- include "digitalmarketplace/components/new-framework-banner/template.njk" -%}
 {% endmacro %}

--- a/src/digitalmarketplace/components/new-framework-banner/new-framework-banner.yaml
+++ b/src/digitalmarketplace/components/new-framework-banner/new-framework-banner.yaml
@@ -1,3 +1,15 @@
 params:
+- name: gCloudLive
+  type: boolean
+  description: Shows the correct banner depending on if there is a live G-Cloud framework
+
 examples:
   - name: default
+
+  - name:  G-Cloud live
+    data:
+      gCloudLive: true
+
+  - name:  G-Cloud not live
+    data:
+      gCloudLive: false

--- a/src/digitalmarketplace/components/new-framework-banner/template.njk
+++ b/src/digitalmarketplace/components/new-framework-banner/template.njk
@@ -5,10 +5,33 @@
     </h2>
   </div>
   <div class="govuk-notification-banner__content">
-    <p class="govuk-notification-banner__heading">
-      Register with CCS's Public Procurement Gateway to get ready for DOS 6.
-      G-Cloud 13 is now live.
-      <a class="govuk-notification-banner__link" href="https://auth.identify.crowncommercial.gov.uk">Sign in to the Public Procurement Gateway</a>.
-    </p>
+    {% if params.gCloudLive %}
+      <p class="govuk-body">
+        Crown Commercial Services advises that GCloud 12 will expire at 09:00 on Monday 28th November.
+      </p>
+
+      <p class="govuk-body">
+        At this time the digital platform for GCloud 12 will be switched off and no services or suppliers will be visible.
+      </p>
+
+      <p class="govuk-body">
+        All procurements being undertaken through GCloud 12 MUST be completed before this time.
+        Any procurement activity started that has not completed by this time will need to be restarted via GCloud 13 which is now live and available through Crown Commercial Services Contract Award Service (CAS).
+        Buyers must
+        <a class="govuk-notification-banner__link" href="https://identify.crowncommercial.gov.uk/manage-org/register">register with Public Procurement Gateway (PPG)</a>
+        in order to use CAS.
+      </p>
+
+      <p class="govuk-body">
+        Information about G-Cloud 13 can be found on the
+        <a class="govuk-notification-banner__link" href="https://www.crowncommercial.gov.uk/agreements/RM1557.13">CCS web page</a>.
+      </p>
+    {% else %}
+      <p class="govuk-notification-banner__heading">
+        Register with CCS's Public Procurement Gateway to get ready for DOS 6.
+        G-Cloud 13 is now live.
+        <a class="govuk-notification-banner__link" href="https://auth.identify.crowncommercial.gov.uk">Sign in to the Public Procurement Gateway</a>.
+      </p>
+    {% endif %}
   </div>
 </div>


### PR DESCRIPTION
Ticket: [OST-583](https://crowncommercialservice.atlassian.net/browse/OST-583)

This is what it will look like:
![Screenshot 2022-11-25 at 10 12 04](https://user-images.githubusercontent.com/58297459/203962009-befb7b6a-259e-4351-9b76-b5b3e48ee347.png)

I've added a conditional param to only show the new banner if there is a live G-Cloud framework. Otherwise it shows the banner in [OST-574](https://crowncommercialservice.atlassian.net/browse/OST-574).