### PR TITLE
Release 3.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See below for Changelog examples.
 
+## 3.11.0
+
+🔧 Changes:
+
+  - Update Banner text again to warn of G-Cloud 12 closing [PR #704](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/704)
+
 ## 3.10.0
 
 🔧 Changes:

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "peerDependencies": {
     "govuk-frontend": "^3.9.1"
   },


### PR DESCRIPTION
🔧 Changes:

  - Update Banner text again to warn of G-Cloud 12 closing [PR #704](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/704)
