### PR TITLE
Release 2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See below for Changelog examples.
 
+## 2.12.0
+
+🔧 Changes:
+
+  - Update Banner text again to warn of G-Cloud 12 closing [PR #705](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/705)
+
 ## 2.11.0
 
 🔧 Changes:

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "peerDependencies": {
     "govuk-frontend": "^2.13.0"
   },


### PR DESCRIPTION
🔧 Changes:

  - Update Banner text again to warn of G-Cloud 12 closing [PR #705](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/705)
