### PR TITLE
Update the banner to include the DOS5 closing dates

### DIFF
--- a/src/digitalmarketplace/components/new-framework-banner/template.njk
+++ b/src/digitalmarketplace/components/new-framework-banner/template.njk
@@ -2,8 +2,9 @@
 
 {% set html %}
   <p class="govuk-notification-banner__heading">
-    <a class="govuk-notification-banner__link" href="https://auth.identify.crowncommercial.gov.uk">Register with CCS's Public Procurement Gateway</a>.
-    DOS 6 and G-Cloud 13 are now live.
+    The DOS 5 framework agreement expires on 19 April 2023.
+    All call-off contracts awarded under DOS 5 must be signed by 19 April.
+    Use <a class="govuk-notification-banner__link" href="https://auth.identify.crowncommercial.gov.uk">Public Procurement Gateway</a> to access DOS 6.
   </p>
 {% endset %}
 


### PR DESCRIPTION
Update the banner to include the DOS5 closing dates.

Here is the banner:
![Screenshot 2023-02-16 at 11 34 55](https://user-images.githubusercontent.com/58297459/219354314-e254fd99-9c11-4419-bc2d-331d3cda694e.png)
