### PR TITLE
Release 3.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See below for Changelog examples.
 
+## 3.11.2
+
+🔧 Changes:
+
+  - Update Banner text again to notify that DOS5 is closing [PR #733](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/733)
+
 ## 3.11.1
 
 🔧 Changes:

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "3.11.1",
+  "version": "3.11.2",
   "peerDependencies": {
     "govuk-frontend": "^3.9.1"
   },


### PR DESCRIPTION
🔧 Changes:

 - Update Banner text again to notify that DOS5 is closing [PR #733](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/733)
