### PR TITLE
Release 2.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See below for Changelog examples.
 
+## 2.12.3
+
+🔧 Changes:
+
+  - Update Banner text again to say the date that DOS5 is closing [PR #758](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/758)
+
 ## 2.12.2
 
 🔧 Changes:

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "2.12.2",
+  "version": "2.12.3",
   "peerDependencies": {
     "govuk-frontend": "^2.13.0"
   },


### PR DESCRIPTION
🔧 Changes:

  - Update Banner text again to say the date that DOS5 is closing [PR #758](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/758)
