### PR TITLE
Release 3.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See below for Changelog examples.
 
+## 3.12.0
+
+🚧 Fixes:
+
+  - Add Google Tag Manager for DMP 1.0 [PR #788](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/788)
+
 ## 3.11.3
 
 🔧 Changes:

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "3.11.3",
+  "version": "3.12.0",
   "peerDependencies": {
     "govuk-frontend": "^3.9.1"
   },


### PR DESCRIPTION
🚧 Fixes:

  - Add Google Tag Manager for DMP 1.0 [PR #788](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/788)
