### PR TITLE
Release 2.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See below for Changelog examples.
 
+## 2.13.0
+
+🚧 Fixes:
+
+  - Add Google Tag Manager for DMP 1.0 [PR #789](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/789)
+
 ## 2.12.3
 
 🔧 Changes:

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-govuk-frontend",
   "description": "Digital Marketplace GOV.UK Frontend contains the code you need to start building a user interface for Digital Marketplace.",
-  "version": "2.12.3",
+  "version": "2.13.0",
   "peerDependencies": {
     "govuk-frontend": "^2.13.0"
   },


### PR DESCRIPTION
🚧 Fixes:

  - Add Google Tag Manager for DMP 1.0 [PR #789](https://github.com/Crown-Commercial-Service/digitalmarketplace-govuk-frontend/pull/789)

